### PR TITLE
feat: on delete cascade추가

### DIFF
--- a/back/src/main/kotlin/com/rookiefit/rookiefit/auth/entity/UserEntity.kt
+++ b/back/src/main/kotlin/com/rookiefit/rookiefit/auth/entity/UserEntity.kt
@@ -1,5 +1,6 @@
 package com.rookiefit.rookiefit.auth.entity
 
+import com.rookiefit.rookiefit.diet.entity.UserDietEntity
 import com.rookiefit.rookiefit.user.entity.UserProfileEntity
 import jakarta.persistence.*
 
@@ -32,6 +33,9 @@ class UserEntity (
     var isLicensed: Boolean = false,
 
     @OneToOne(mappedBy = "user", cascade = [CascadeType.ALL], orphanRemoval = true)
-    var userProfile: UserProfileEntity? = null
+    var userProfile: UserProfileEntity? = null,
+
+    @OneToMany(mappedBy = "user", cascade = [CascadeType.ALL], orphanRemoval = true)
+    var userDiets: MutableList<UserDietEntity> = mutableListOf()
 )
 

--- a/back/src/main/kotlin/com/rookiefit/rookiefit/diet/dto/UserDietDto.kt
+++ b/back/src/main/kotlin/com/rookiefit/rookiefit/diet/dto/UserDietDto.kt
@@ -13,7 +13,7 @@ data class UserDietDto(
         fun fromEntity(entity: UserDietEntity): UserDietDto {
             return UserDietDto(
                 id = entity.id,
-                userId = entity.userId,
+                userId = entity.user.userId,
                 dietDate = entity.dietDate,
                 totalCalories = entity.totalCalories,
                 dietDetails = entity.details.map { UserDietDetailDto.fromEntity(it) }

--- a/back/src/main/kotlin/com/rookiefit/rookiefit/diet/entity/UserDietEntity.kt
+++ b/back/src/main/kotlin/com/rookiefit/rookiefit/diet/entity/UserDietEntity.kt
@@ -1,5 +1,6 @@
 package com.rookiefit.rookiefit.diet.entity
 
+import com.rookiefit.rookiefit.auth.entity.UserEntity
 import jakarta.persistence.*
 
 @Entity
@@ -9,7 +10,10 @@ class UserDietEntity(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0,
 
-    val userId: String,
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    var user: UserEntity,
+
     val dietDate: String,
 
     var totalCalories: Double = 0.0,

--- a/back/src/main/kotlin/com/rookiefit/rookiefit/diet/repository/UserDietRepository.kt
+++ b/back/src/main/kotlin/com/rookiefit/rookiefit/diet/repository/UserDietRepository.kt
@@ -2,13 +2,9 @@ package com.rookiefit.rookiefit.diet.repository
 
 import com.rookiefit.rookiefit.diet.entity.UserDietEntity
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.stereotype.Repository
 
-
-@Repository
 interface UserDietRepository : JpaRepository<UserDietEntity, Long> {
-    // 특정 사용자와 날짜로 식단 정보를 조회
-    fun findByUserIdAndDietDate(userId: String, dietDate: String): UserDietEntity?
+    // user 객체를 통해 userId를 참조할 수 있도록 수정
+    fun findByUser_UserIdAndDietDate(userId: String, dietDate: String): UserDietEntity?
 }
-
 

--- a/back/src/main/kotlin/com/rookiefit/rookiefit/diet/service/UserDietService.kt
+++ b/back/src/main/kotlin/com/rookiefit/rookiefit/diet/service/UserDietService.kt
@@ -7,6 +7,7 @@ import com.rookiefit.rookiefit.diet.entity.UserDietEntity
 import com.rookiefit.rookiefit.diet.repository.FoodInfoRepository
 import com.rookiefit.rookiefit.diet.repository.UserDietDetailRepository
 import com.rookiefit.rookiefit.diet.repository.UserDietRepository
+import com.rookiefit.rookiefit.auth.repository.UserRepository
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -15,21 +16,25 @@ import org.springframework.transaction.annotation.Transactional
 class UserDietService(
     private val userDietRepository: UserDietRepository,
     private val userDietDetailRepository: UserDietDetailRepository,
-    private val foodInfoRepository: FoodInfoRepository
+    private val foodInfoRepository: FoodInfoRepository,
+    private val userRepository: UserRepository
 ) {
 
     // 특정 날짜의 식단 조회
     fun getUserDietList(userId: String, dietDate: String): UserDietDto? {
-        val userDiet = userDietRepository.findByUserIdAndDietDate(userId, dietDate) ?: return null
+        val userDiet = userDietRepository.findByUser_UserIdAndDietDate(userId, dietDate) ?: return null
         return UserDietDto.fromEntity(userDiet)
     }
 
     // 식단에 음식 추가
     @Transactional
     fun addFoodToDiet(request: AddFoodToDietRequest): UserDietDto {
-        val userDiet = userDietRepository.findByUserIdAndDietDate(request.userId, request.dietDate)
-            ?: UserDietEntity(userId = request.userId, dietDate = request.dietDate).also {
-                userDietRepository.save(it)  // 없으면 새로 생성 후 저장
+        val user = userRepository.findById(request.userId)
+            .orElseThrow { IllegalArgumentException("User not found: ${request.userId}") }
+
+        val userDiet = userDietRepository.findByUser_UserIdAndDietDate(request.userId, request.dietDate)
+            ?: UserDietEntity(user = user, dietDate = request.dietDate).also {
+                userDietRepository.save(it)
             }
 
         // 음식 추가
@@ -50,44 +55,45 @@ class UserDietService(
         }
 
         // 기존 데이터 삭제 후 새 데이터 추가 (덮어쓰기 개념)
-        userDietDetailRepository.deleteAllByUserDiet(userDiet)
         userDiet.details.clear()
         userDiet.details.addAll(foodDetails)
 
         userDiet.updateTotalCalories()
 
-        val savedDiet = userDietRepository.save(userDiet)
-        return UserDietDto.fromEntity(savedDiet)
+        return UserDietDto.fromEntity(userDietRepository.save(userDiet))
     }
 
     // 식단에서 특정 음식 삭제
     @Transactional
     fun deleteFoodFromDiet(userDietDetailId: Long): ResponseEntity<String> {
-        val userDietDetail = userDietDetailRepository.findById(userDietDetailId).orElse(null)
-            ?: throw IllegalArgumentException("해당 음식이 식단에 존재하지 않습니다.")
+        val userDietDetail = userDietDetailRepository.findById(userDietDetailId)
+            .orElseThrow { IllegalArgumentException("해당 음식이 식단에 존재하지 않습니다.") }
 
         val userDiet = userDietDetail.userDiet
+
+        // 삭제된 userDietDetail을 userDiet의 details 리스트에서 제거
+        userDiet.details.remove(userDietDetail)
 
         // 음식 삭제
         userDietDetailRepository.deleteById(userDietDetailId)
 
-        // JPA가 삭제를 반영하도록 flush 호출
-        userDietDetailRepository.flush()
-
         // 삭제 후 totalCalories를 갱신
         userDiet.updateTotalCalories()
+
+        // 변경된 정보를 저장 (삭제 후 갱신된 총 칼로리 반영)
+        userDietRepository.save(userDiet)
+
         return ResponseEntity.ok("음식이 성공적으로 삭제되었습니다.")
     }
 
+    // 특정 날짜의 식단 삭제
     @Transactional
     fun deleteDietByDate(userId: String, dietDate: String): ResponseEntity<String> {
-        // 해당 날짜의 식단을 찾음
-        val userDiet = userDietRepository.findByUserIdAndDietDate(userId, dietDate)
+        val userDiet = userDietRepository.findByUser_UserIdAndDietDate(userId, dietDate)
             ?: throw IllegalArgumentException("해당 날짜의 식단이 존재하지 않습니다.")
 
-        // 해당 날짜의 식단에 포함된 모든 음식들 삭제
-        userDietDetailRepository.deleteAllByUserDiet(userDiet)  // 식단에 포함된 음식들 삭제
-        userDietRepository.delete(userDiet)  // 식단 자체 삭제
+        // 식단 삭제
+        userDietRepository.delete(userDiet)
 
         return ResponseEntity.ok("해당 날짜의 식단이 성공적으로 삭제되었습니다.")
     }


### PR DESCRIPTION
user_auth와 user_diet테이블 연결

close #<이슈 번호> <!-- 예: close #123 -->

## 🛠️ PR 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [x] DB설정변경

## 📝 변경 사항
<!--- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. -->

## 💬 공유사항 to 리뷰어
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## Sourcery 요약

외래 키 관계를 설정하여 `user_auth` 테이블과 `user_diet` 테이블을 연결합니다. 이 변경 사항은 사용자 인증 정보와 식단 기록 간의 데이터 일관성 및 무결성을 보장합니다.

개선 사항:
- `UserDietEntity`를 리팩터링하여 `userId`를 직접 저장하는 대신 `UserEntity`를 참조하도록 변경합니다.
- `UserDietRepository`를 수정하여 쿼리에서 `UserEntity`를 사용하도록 변경합니다.
- `UserDietService`를 업데이트하여 식단 및 음식 항목을 생성하고 삭제할 때 새로운 관계를 사용하도록 하여 적절한 데이터 관리 및 일관성을 보장합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Connects the user_auth and user_diet tables by establishing a foreign key relationship. This change ensures data consistency and integrity between user authentication information and dietary records.

Enhancements:
- Refactor UserDietEntity to reference UserEntity instead of storing userId directly.
- Modify UserDietRepository to use the UserEntity in queries.
- Update UserDietService to use the new relationships when creating and deleting diets and food entries, ensuring proper data management and consistency.

</details>