### PR TITLE
feat: 체성분 그래프 api 구현

### DIFF
--- a/back/src/main/kotlin/com/rookiefit/rookiefit/user/controller/UserDataController.kt
+++ b/back/src/main/kotlin/com/rookiefit/rookiefit/user/controller/UserDataController.kt
@@ -3,8 +3,7 @@ package com.rookiefit.rookiefit.user.controller
 import com.rookiefit.rookiefit.auth.dto.ResponseDTO
 import com.rookiefit.rookiefit.user.dto.UserInfoDTO
 import com.rookiefit.rookiefit.user.dto.UserProfileDTO
-import com.rookiefit.rookiefit.user.dto.response.UserInfoResponseDTO
-import com.rookiefit.rookiefit.user.dto.response.UserProfileResponseDTO
+import com.rookiefit.rookiefit.user.dto.response.*
 import com.rookiefit.rookiefit.user.service.UserDataService
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -55,6 +54,30 @@ class UserDataController(
         val authentication = SecurityContextHolder.getContext().authentication
         val currentUserId = authentication?.principal as String
         val responseBody = userDataService.getUserInfo(currentUserId)
+        return responseBody
+    }
+
+    @GetMapping("/getuserweightdata")
+    fun getUserWeightData(): List<UserWeightResponseDTO> {
+        val authentication = SecurityContextHolder.getContext().authentication
+        val currentUserId = authentication?.principal as String
+        val responseBody = userDataService.getUserWeightData(currentUserId)
+        return responseBody
+    }
+
+    @GetMapping("/getusermuscledata")
+    fun getuserMuscledata(): List<UserMuscleResponseDTO> {
+        val authentication = SecurityContextHolder.getContext().authentication
+        val currentUserId = authentication?.principal as String
+        val responseBody = userDataService.getuserMuscledata(currentUserId)
+        return responseBody
+    }
+
+    @GetMapping("/getuserfatdata")
+    fun getuserFatdata(): List<UserFatResponseDTO> {
+        val authentication = SecurityContextHolder.getContext().authentication
+        val currentUserId = authentication?.principal as String
+        val responseBody = userDataService.getuserFatdata(currentUserId)
         return responseBody
     }
 }

--- a/back/src/main/kotlin/com/rookiefit/rookiefit/user/dto/response/UserFatResponseDTO.kt
+++ b/back/src/main/kotlin/com/rookiefit/rookiefit/user/dto/response/UserFatResponseDTO.kt
@@ -1,0 +1,6 @@
+package com.rookiefit.rookiefit.user.dto.response
+
+data class UserFatResponseDTO(
+    val userInfoFatMass: String,
+    val userInfoInbodyDate: String,
+)

--- a/back/src/main/kotlin/com/rookiefit/rookiefit/user/dto/response/UserMuscleResponseDTO.kt
+++ b/back/src/main/kotlin/com/rookiefit/rookiefit/user/dto/response/UserMuscleResponseDTO.kt
@@ -1,0 +1,6 @@
+package com.rookiefit.rookiefit.user.dto.response
+
+data class UserMuscleResponseDTO(
+    val userInfoMuscleMass: String,
+    val userInfoInbodyDate: String,
+)

--- a/back/src/main/kotlin/com/rookiefit/rookiefit/user/dto/response/UserWeightResponseDTO.kt
+++ b/back/src/main/kotlin/com/rookiefit/rookiefit/user/dto/response/UserWeightResponseDTO.kt
@@ -1,0 +1,6 @@
+package com.rookiefit.rookiefit.user.dto.response
+
+data class UserWeightResponseDTO(
+    val userInfoWeight: String,
+    val userInfoInbodyDate: String,
+)

--- a/back/src/main/kotlin/com/rookiefit/rookiefit/user/repository/UserInfoRepository.kt
+++ b/back/src/main/kotlin/com/rookiefit/rookiefit/user/repository/UserInfoRepository.kt
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface UserInfoRepository: JpaRepository<UserInfoEntity, Long> {
     fun findByUserProfile_UserProfileId(userProfileId: Long): List<UserInfoEntity>?
     fun findByUserInfoInbodyDate( userInfoInBodyDate: String): UserInfoEntity?
+    fun findTop7ByUserProfile_UserProfileIdOrderByUserInfoInbodyDateAsc(userProfileId: Long): List<UserInfoEntity>?
 }

--- a/back/src/main/kotlin/com/rookiefit/rookiefit/user/service/UserDataService.kt
+++ b/back/src/main/kotlin/com/rookiefit/rookiefit/user/service/UserDataService.kt
@@ -5,8 +5,7 @@ import com.rookiefit.rookiefit.auth.repository.UserRepository
 import com.rookiefit.rookiefit.common.FirebaseService
 import com.rookiefit.rookiefit.user.dto.UserInfoDTO
 import com.rookiefit.rookiefit.user.dto.UserProfileDTO
-import com.rookiefit.rookiefit.user.dto.response.UserInfoResponseDTO
-import com.rookiefit.rookiefit.user.dto.response.UserProfileResponseDTO
+import com.rookiefit.rookiefit.user.dto.response.*
 import com.rookiefit.rookiefit.user.entity.UserInfoEntity
 import com.rookiefit.rookiefit.user.repository.UserInfoRepository
 import com.rookiefit.rookiefit.user.repository.UserProfileRepository
@@ -127,5 +126,26 @@ class UserDataService(
             userInfoMuscleMass = latestUserInfo.userInfoMuscleMass,
             userInfoFatMass = latestUserInfo.userInfoFatMass
         )
+    }
+
+    fun getUserWeightData(currentUserId: String?): List<UserWeightResponseDTO> {
+        val userProfileEntity = userProfileRepository.findByUser_UserId(currentUserId)
+            ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 사용자")
+        return userInfoRepository.findTop7ByUserProfile_UserProfileIdOrderByUserInfoInbodyDateAsc(userProfileEntity.userProfileId)
+            ?.map { UserWeightResponseDTO(it.userInfoWeight.toString(), it.userInfoInbodyDate.toString()) } ?: emptyList()
+    }
+
+    fun getuserMuscledata(currentUserId: String?): List<UserMuscleResponseDTO> {
+        val userProfileEntity = userProfileRepository.findByUser_UserId(currentUserId)
+            ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 사용자")
+        return userInfoRepository.findTop7ByUserProfile_UserProfileIdOrderByUserInfoInbodyDateAsc(userProfileEntity.userProfileId)
+            ?.map { UserMuscleResponseDTO(it.userInfoMuscleMass.toString(), it.userInfoInbodyDate.toString()) } ?: emptyList()
+    }
+
+    fun getuserFatdata(currentUserId: String?): List<UserFatResponseDTO> {
+        val userProfileEntity = userProfileRepository.findByUser_UserId(currentUserId)
+            ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 사용자")
+        return userInfoRepository.findTop7ByUserProfile_UserProfileIdOrderByUserInfoInbodyDateAsc(userProfileEntity.userProfileId)
+            ?.map { UserFatResponseDTO(it.userInfoFatMass.toString(), it.userInfoInbodyDate.toString()) } ?: emptyList()
     }
 }


### PR DESCRIPTION
close #<이슈 번호> <!-- 예: close #123 -->

## 🛠️ PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] DB설정변경

## 📝 변경 사항
<!--- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. -->

## 💬 공유사항 to 리뷰어
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## Sourcery 요약

그래프 시각화를 위해 사용자 체중, 근육, 지방 데이터를 검색하는 API 엔드포인트를 구현합니다. API는 각 데이터 유형의 마지막 7개 항목을 반환합니다.

새로운 기능:
- 사용자 체중, 근육, 지방 데이터를 검색하는 API 엔드포인트를 추가합니다.
- 사용자 체중, 근육, 지방 데이터의 마지막 7개 항목을 반환합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implements API endpoints to retrieve user weight, muscle, and fat data for graph visualization. The API returns the last 7 entries of each data type.

New Features:
- Adds API endpoints to retrieve user weight, muscle, and fat data.
- Returns the last 7 entries of user weight, muscle, and fat data.

</details>