### PR TITLE
chore: token을 request에서 받아오게 수정

### DIFF
--- a/back/src/main/kotlin/com/rookiefit/rookiefit/diet/controller/UserDietController.kt
+++ b/back/src/main/kotlin/com/rookiefit/rookiefit/diet/controller/UserDietController.kt
@@ -24,19 +24,20 @@ class UserDietController(private val userDietService: UserDietService, private v
 
     // 식단에 음식 추가
     @PostMapping("/list/add")
-    fun addFoodToDiet(@RequestBody request: AddFoodToDietRequest, @RequestHeader("Authorization") authorization: String): ResponseEntity<UserDietDto> {
+    fun addFoodToDiet(@RequestBody request: AddFoodToDietRequest,
+                      @RequestHeader("Authorization") authorization: String): ResponseEntity<UserDietDto> {
         val userId = jwtProvider.extractUserId(authorization.replace("Bearer ", ""))
-        val updatedDiet = userDietService.addFoodToDiet(request)
+        val updatedDiet = userDietService.addFoodToDiet(userId, request)
         return ResponseEntity.ok(updatedDiet)
     }
 
     // 식단에서 특정 음식 삭제
-    @DeleteMapping("/list/delete/{detailId}")
+    /*@DeleteMapping("/list/delete/{detailId}")
     fun deleteFoodFromDiet(@PathVariable detailId: Long, @RequestHeader("Authorization") authorization: String): ResponseEntity<Unit> {
         val userId = jwtProvider.extractUserId(authorization.replace("Bearer ", ""))
-        userDietService.deleteFoodFromDiet(detailId)
+        userDietService.deleteFoodFromDiet(userId, detailId)
         return ResponseEntity.noContent().build()
-    }
+    }*/
 
     // 특정 날짜의 식단 삭제
     @DeleteMapping("/delete")
@@ -48,5 +49,3 @@ class UserDietController(private val userDietService: UserDietService, private v
         return userDietService.deleteDietByDate(userId, dietDate)
     }
 }
-
-

--- a/back/src/main/kotlin/com/rookiefit/rookiefit/diet/dto/request/AddFoodToDietRequest.kt
+++ b/back/src/main/kotlin/com/rookiefit/rookiefit/diet/dto/request/AddFoodToDietRequest.kt
@@ -3,7 +3,6 @@ package com.rookiefit.rookiefit.diet.dto.request
 import com.rookiefit.rookiefit.diet.dto.UserDietDetailDto
 
 data class AddFoodToDietRequest(
-    val userId: String,
     val dietDate: String,
     val dietDetails: List<UserDietDetailDto>
 )

--- a/back/src/main/kotlin/com/rookiefit/rookiefit/diet/service/UserDietService.kt
+++ b/back/src/main/kotlin/com/rookiefit/rookiefit/diet/service/UserDietService.kt
@@ -28,16 +28,20 @@ class UserDietService(
 
     // 식단에 음식 추가
     @Transactional
-    fun addFoodToDiet(request: AddFoodToDietRequest): UserDietDto {
-        val user = userRepository.findById(request.userId)
-            .orElseThrow { IllegalArgumentException("User not found: ${request.userId}") }
+    fun addFoodToDiet(userId: String, request: AddFoodToDietRequest): UserDietDto {
+        val user = userRepository.findById(userId)
+            .orElseThrow { IllegalArgumentException("User not found: $userId") }
 
-        val userDiet = userDietRepository.findByUser_UserIdAndDietDate(request.userId, request.dietDate)
+        val userDiet = userDietRepository.findByUser_UserIdAndDietDate(userId, request.dietDate)
             ?: UserDietEntity(user = user, dietDate = request.dietDate).also {
                 userDietRepository.save(it)
             }
 
-        // 음식 추가
+        // 기존 데이터 삭제 (DB에서도 삭제)
+        userDietDetailRepository.deleteAll(userDiet.details)
+        userDiet.details.clear()
+
+        // 새 음식 추가
         val foodDetails = request.dietDetails.map { detail ->
             val foodInfo = foodInfoRepository.findByFoodName(detail.foodName)
                 ?: throw IllegalArgumentException("${detail.foodName} 식품이 존재하지 않습니다.")
@@ -54,18 +58,15 @@ class UserDietService(
             )
         }
 
-        // 기존 데이터 삭제 후 새 데이터 추가 (덮어쓰기 개념)
-        userDiet.details.clear()
         userDiet.details.addAll(foodDetails)
-
         userDiet.updateTotalCalories()
 
         return UserDietDto.fromEntity(userDietRepository.save(userDiet))
     }
 
     // 식단에서 특정 음식 삭제
-    @Transactional
-    fun deleteFoodFromDiet(userDietDetailId: Long): ResponseEntity<String> {
+    /*@Transactional
+    fun deleteFoodFromDiet(userId: String, userDietDetailId: Long): ResponseEntity<String> {
         val userDietDetail = userDietDetailRepository.findById(userDietDetailId)
             .orElseThrow { IllegalArgumentException("해당 음식이 식단에 존재하지 않습니다.") }
 
@@ -84,7 +85,7 @@ class UserDietService(
         userDietRepository.save(userDiet)
 
         return ResponseEntity.ok("음식이 성공적으로 삭제되었습니다.")
-    }
+    }*/
 
     // 특정 날짜의 식단 삭제
     @Transactional


### PR DESCRIPTION
close #<이슈 번호> <!-- 예: close #123 -->

## 🛠️ PR 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] DB설정변경

## 📝 변경 사항
<!--- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. -->

## 💬 공유사항 to 리뷰어
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## Sourcery 요약

식단 서비스 메서드에서 토큰 기반 사용자 식별을 수정합니다.

개선 사항:
- 식단 서비스 메서드를 리팩터링하여 사용자 ID를 파라미터로 받는 대신 JWT 토큰에서 추출합니다.

잡일:
- 식단 관련 요청 DTO 및 서비스 메서드에서 명시적인 사용자 ID 파라미터를 제거합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Modify token-based user identification in diet service methods

Enhancements:
- Refactor diet service methods to extract user ID from JWT token instead of receiving it as a parameter

Chores:
- Remove explicit user ID parameter from diet-related request DTOs and service methods

</details>